### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/xml-validation.yml
+++ b/.github/workflows/xml-validation.yml
@@ -1,5 +1,7 @@
 # .github/workflows/xml-validation.yml
 name: "XML Schema Validation"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Fayeblade1488/APPDEV-MAESTRO/security/code-scanning/1](https://github.com/Fayeblade1488/APPDEV-MAESTRO/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code and runs validation scripts, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow file, just after the `name` field and before the `on` field. This will apply the permission restriction to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Restrict GITHUB_TOKEN permissions in the XML Schema Validation workflow to the minimum required

Bug Fixes:
- Restrict GITHUB_TOKEN to read-only repository contents in xml-validation workflow to address code scanning alert

CI:
- Add permissions block with contents: read to xml-validation workflow